### PR TITLE
add base security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,10 @@
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+
+[[headers]]
+for = "/*"
+
+[headers.values]
+   X-Content-Type-Options = "nosniff"
+          X-Frame-Options = "DENY"


### PR DESCRIPTION
Current Mozilla Observatory score is a D+, and adding some basic security headers should improve this. It would be ideal to implement a Content Security Policy, but that's much more involved than the low-hanging fruit of setting these headers.

X-Frame-Options keeps other browsers from rendering this inside an iframe on a malicious site.

X-Content-Type-Options (along with content-type, already set in headers), is effective against Mime sniffing, possibly leading to XSS attacks.

X-XSS-Protection is another possible header, but it's been deprecated, and not recommended over a comprehensive CSP, so I didn't include it here.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection


![scan of current site](https://user-images.githubusercontent.com/5070516/155036956-1521d8e0-deaf-4994-be7f-1726b49dc481.png)

