### PR TITLE
fix: theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -5,10 +5,10 @@ import { styled } from "~/stitches.config";
 import { SecondaryButton } from "./SecondaryButton";
 
 export const ThemeToggle = () => {
-  const { theme, setTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   return (
     <Button
-      onClick={() => (theme === "dark" ? setTheme("light") : setTheme("dark"))}
+      onClick={() => (resolvedTheme === "dark" ? setTheme("light") : setTheme("dark"))}
     >
       <BiSun />
     </Button>


### PR DESCRIPTION
Fix #81 

This should be compared against `resolvedTheme`. Otherwise, `theme` can be `system`, so the `=== 'dark'` fails, which assumes to be `light`.